### PR TITLE
Command refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ For a simple plugin, we pack a few powerful features!
 
 ### Permissions
 `mobactions.*` - Grants access to all warps and all other permissions (Default: disabled)  
-`mobactions.command.*` - Allows players to use all command mobs (Default: enabled)  
-`mobactions.command.[command]` - Allows players to use specific command mobs (Default: disabled)  
+`mobactions.command` - Allows players to use all command mobs (Default: enabled)  
 `mobactions.warp` - Allows players to go to a warp using /mac warp. Also needed for /mac warps (Default: op)  
 `mobactions.warp.*` - Allows players to use all mob portals (Default: enabled)  
 `mobactions.warp.[warp]` - Allows players to use portals to the specific warp (Default: disabled)

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Tested Minecraft Versions: **1.16**
 For a simple plugin, we pack a few powerful features!
 
 ### Commands
-`/mac create command <name> "command" "description"` - Create a new command mob  
-`/mac create warp <warp>` - Create a new warp mob  
+`/mac create command "command" "description"` - Create a new command mob  
+`/mac create warp <name>` - Create a new warp mob  
 `/mac remove` - Remove a mob's action  
 `/mac cancel` - Cancels the current operation  
 `/mac warp <warp>` - Teleport to a warp  

--- a/src/main/java/com/snowypeaksystems/mobactions/actions/CommandAction.java
+++ b/src/main/java/com/snowypeaksystems/mobactions/actions/CommandAction.java
@@ -23,7 +23,7 @@ public class CommandAction implements ICommandAction {
   @Override
   public void run(MobActionsUser player) throws PlayerException {
     DebugLogger.getLogger().log("Executing command");
-    if (!player.canRunCommand(command.getAlias())) {
+    if (!player.canRunCommand()) {
       DebugLogger.getLogger().log("Permission error");
       throw new PermissionException();
     }

--- a/src/main/java/com/snowypeaksystems/mobactions/data/CommandData.java
+++ b/src/main/java/com/snowypeaksystems/mobactions/data/CommandData.java
@@ -13,7 +13,6 @@ import org.bukkit.plugin.java.JavaPlugin;
  * @author Copyright (c) Levi Muniz. All Rights Reserved.
  */
 public class CommandData implements ICommandData {
-  private final String name;
   private final String command;
   private final String description;
   private final String tokenStr = String.valueOf(new char[]{TOKEN_PREFIX, TOKEN_SUFFIX});
@@ -21,24 +20,20 @@ public class CommandData implements ICommandData {
   /** Constructs CommandData from an entity. */
   public CommandData(LivingEntity entity, JavaPlugin plugin) throws IncompleteDataException {
     PersistentDataContainer container = entity.getPersistentDataContainer();
-    NamespacedKey aliasKey = new NamespacedKey(plugin, COMMAND_ALIAS_KEY);
     NamespacedKey commandKey = new NamespacedKey(plugin, COMMAND_KEY);
     NamespacedKey descriptionKey = new NamespacedKey(plugin, COMMAND_DESCRIPTION_KEY);
 
-    if (!container.has(aliasKey, PersistentDataType.STRING)
-        || !container.has(commandKey, PersistentDataType.STRING)
+    if (!container.has(commandKey, PersistentDataType.STRING)
         || !container.has(descriptionKey, PersistentDataType.STRING)) {
       throw new IncompleteDataException();
     }
 
-    this.name = container.get(aliasKey, PersistentDataType.STRING);
     this.command = container.get(commandKey, PersistentDataType.STRING);
     this.description = container.get(descriptionKey, PersistentDataType.STRING);
   }
 
   /** Constructs a command given a name and command to execute. */
-  public CommandData(String name, String command, String description) {
-    this.name = name;
+  public CommandData(String command, String description) {
     this.command = command;
     this.description = description;
   }
@@ -69,16 +64,9 @@ public class CommandData implements ICommandData {
   }
 
   @Override
-  public String getAlias() {
-    return name;
-  }
-
-  @Override
   public void store(LivingEntity entity, JavaPlugin plugin) {
     entity.getPersistentDataContainer()
         .set(new NamespacedKey(plugin, COMMAND_KEY), PersistentDataType.STRING, command);
-    entity.getPersistentDataContainer()
-        .set(new NamespacedKey(plugin, COMMAND_ALIAS_KEY), PersistentDataType.STRING, name);
     entity.getPersistentDataContainer()
         .set(new NamespacedKey(plugin, COMMAND_DESCRIPTION_KEY),
             PersistentDataType.STRING, description);
@@ -87,7 +75,6 @@ public class CommandData implements ICommandData {
   @Override
   public void purge(LivingEntity entity, JavaPlugin plugin) {
     entity.getPersistentDataContainer().remove(new NamespacedKey(plugin, COMMAND_KEY));
-    entity.getPersistentDataContainer().remove(new NamespacedKey(plugin, COMMAND_ALIAS_KEY));
     entity.getPersistentDataContainer().remove(new NamespacedKey(plugin, COMMAND_DESCRIPTION_KEY));
   }
 

--- a/src/main/java/com/snowypeaksystems/mobactions/data/ICommandData.java
+++ b/src/main/java/com/snowypeaksystems/mobactions/data/ICommandData.java
@@ -8,7 +8,6 @@ public interface ICommandData extends MobData {
   char TOKEN_PREFIX = '{';
   char TOKEN_SUFFIX = '}';
   String COMMAND_KEY = "command";
-  String COMMAND_ALIAS_KEY = "command-alias";
   String COMMAND_DESCRIPTION_KEY = "command-description";
 
   /** Returns the command String with the token replaced by name. */

--- a/src/main/java/com/snowypeaksystems/mobactions/data/IWarpData.java
+++ b/src/main/java/com/snowypeaksystems/mobactions/data/IWarpData.java
@@ -4,6 +4,6 @@ package com.snowypeaksystems.mobactions.data;
  * Stores IWarp information.
  * @author Copyright (c) Levi Muniz. All Rights Reserved.
  */
-public interface IWarpData extends MobData {
+public interface IWarpData extends MobData, AliasedData {
   String WARP_KEY = "warp";
 }

--- a/src/main/java/com/snowypeaksystems/mobactions/data/MobData.java
+++ b/src/main/java/com/snowypeaksystems/mobactions/data/MobData.java
@@ -10,7 +10,7 @@ import org.bukkit.plugin.java.JavaPlugin;
  * Data that can be stored by a Mob.
  * @author Copyright (c) Levi Muniz. All Rights Reserved.
  */
-public interface MobData extends AliasedData {
+public interface MobData {
   /** Stores the data on the entity. */
   void store(LivingEntity entity, JavaPlugin plugin);
 

--- a/src/main/java/com/snowypeaksystems/mobactions/listener/CommandListener.java
+++ b/src/main/java/com/snowypeaksystems/mobactions/listener/CommandListener.java
@@ -33,7 +33,7 @@ public class CommandListener implements ICommandListener {
   // TODO: Add to Messages class
   private final String[] help = {
       "Usage: /mac <subcommand>",
-      "/mac create command <name> \"command\" \"description\" - Create a new command mob",
+      "/mac create command \"command\" \"description\" - Create a new command mob",
       "/mac create warp <warp> - Create a new warp mob",
       "/mac remove - Remove a mob's action",
       "/mac cancel - Cancels the current operation",
@@ -105,14 +105,14 @@ public class CommandListener implements ICommandListener {
       MobActionsUser user = ma.getPlayer(sender);
       PlayerCommand cmd = null;
 
-      if (args.length > 3 && args[0].equalsIgnoreCase("create")
+      if (args.length >= 4 && args[0].equalsIgnoreCase("create")
           && args[1].equalsIgnoreCase("command")) {
-        String[] sublist = Arrays.asList(args).subList(3, args.length).toArray(new String[]{});
+        String[] sublist = Arrays.asList(args).subList(2, args.length).toArray(new String[]{});
         List<String> strArgs = parseForStrings(sublist);
 
         DebugLogger.getLogger().log("String arguments: " + strArgs.toString());
         if (strArgs.size() == 2) {
-          cmd = new CreateCommand(new CommandData(args[2], strArgs.get(0), strArgs.get(1)));
+          cmd = new CreateCommand(new CommandData(strArgs.get(0), strArgs.get(1)));
         }
       } else if (args.length == 3 && args[0].equalsIgnoreCase("create")
           && args[1].equalsIgnoreCase("warp")) {

--- a/src/main/java/com/snowypeaksystems/mobactions/player/ConsoleUser.java
+++ b/src/main/java/com/snowypeaksystems/mobactions/player/ConsoleUser.java
@@ -21,7 +21,7 @@ public class ConsoleUser implements MobActionsUser {
   }
 
   @Override
-  public boolean canRunCommand(String command) {
+  public boolean canRunCommand() {
     return false;
   }
 

--- a/src/main/java/com/snowypeaksystems/mobactions/player/MobActionsPlayer.java
+++ b/src/main/java/com/snowypeaksystems/mobactions/player/MobActionsPlayer.java
@@ -55,9 +55,8 @@ public class MobActionsPlayer implements MobActionsUser {
   }
 
   @Override
-  public boolean canRunCommand(String command) {
-    return player.hasPermission("mobactions.command.*")
-        || player.hasPermission("mobactions.command." + command);
+  public boolean canRunCommand() {
+    return player.hasPermission("mobactions.command");
   }
 
   @Override

--- a/src/main/java/com/snowypeaksystems/mobactions/player/MobActionsUser.java
+++ b/src/main/java/com/snowypeaksystems/mobactions/player/MobActionsUser.java
@@ -28,7 +28,7 @@ public interface MobActionsUser {
 
   boolean canUseWarp(String warp);
 
-  boolean canRunCommand(String command);
+  boolean canRunCommand();
 
   boolean canCreate();
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -15,8 +15,8 @@ permissions:
   mobactions.warp.*:
     description: Allows players to use all warps, or specify a warp name instead of *
     default: true
-  mobactions.command.*:
-    description: Allows players to use all commands, or specify a command alias instead of *
+  mobactions.command:
+    description: Allows players to use all command mobs
     default: true
   mobactions.warp:
     description: Allows players to go to a warp using /mac warp
@@ -51,5 +51,5 @@ permissions:
     children:
       mobactions.warp: true
       mobactions.admin.*: true
-      mobactions.command.*: true
+      mobactions.command: true
       mobactions.warp.*: true

--- a/src/test/java/com/snowypeaksystems/mobactions/data/command/CommandDataTest.java
+++ b/src/test/java/com/snowypeaksystems/mobactions/data/command/CommandDataTest.java
@@ -13,16 +13,11 @@ import org.junit.jupiter.api.Test;
 class CommandDataTest {
   @Test
   void replace() {
-    ICommandData data = new CommandData("", "te{}st", "");
+    ICommandData data = new CommandData("te{}st", "");
     assertEquals("test test", data.getCommand("st te"));
 
-    data = new CommandData("", "{}st {}st", "");
+    data = new CommandData("{}st {}st", "");
     assertEquals("test test", data.getCommand("te"));
   }
 
-  @Test
-  void getAlias() {
-    ICommandData data = new CommandData("test", "", "");
-    assertEquals("test", data.getAlias());
-  }
 }

--- a/src/test/java/com/snowypeaksystems/mobactions/player/ConsoleUserTest.java
+++ b/src/test/java/com/snowypeaksystems/mobactions/player/ConsoleUserTest.java
@@ -25,7 +25,7 @@ class ConsoleUserTest {
   @Test
   void canRunCommand() {
     MobActionsUser console = new ConsoleUser(new FakeConsoleCommandSender());
-    assertFalse(console.canRunCommand(""));
+    assertFalse(console.canRunCommand());
   }
 
   @Test

--- a/src/test/java/com/snowypeaksystems/mobactions/player/MobActionsPlayerTest.java
+++ b/src/test/java/com/snowypeaksystems/mobactions/player/MobActionsPlayerTest.java
@@ -3,8 +3,6 @@ package com.snowypeaksystems.mobactions.player;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.snowypeaksystems.mobactions.data.CommandData;
-import com.snowypeaksystems.mobactions.data.ICommandData;
 import com.snowypeaksystems.mobactions.mock.FakePlayer;
 import org.junit.jupiter.api.Test;
 
@@ -33,17 +31,12 @@ class MobActionsPlayerTest {
   void canRunCommand() {
     FakePlayer fake = new FakePlayer();
     MobActionsUser player = new MobActionsPlayer(fake);
-    ICommandData command = new CommandData("test1", "", "");
 
-    assertFalse(player.canRunCommand(command.getAlias()));
+    assertFalse(player.canRunCommand());
 
-    fake.setPermission("mobactions.command.test1", true);
-    assertTrue(player.canRunCommand(command.getAlias()));
-    fake.setPermission("mobactions.command.test1", false);
-
-    fake.setPermission("mobactions.command.*", true);
-    assertTrue(player.canRunCommand(command.getAlias()));
-    fake.setPermission("mobactions.command.*", false);
+    fake.setPermission("mobactions.command", true);
+    assertTrue(player.canRunCommand());
+    fake.setPermission("mobactions.command", false);
   }
 
   @Test

--- a/src/test/java/com/snowypeaksystems/mobactions/player/StatusTest.java
+++ b/src/test/java/com/snowypeaksystems/mobactions/player/StatusTest.java
@@ -33,7 +33,7 @@ class StatusTest {
 
   @Test
   void getMobData() {
-    ICommandData command = new CommandData("", "", "");
+    ICommandData command = new CommandData("", "");
 
     IStatus status = new Status();
     assertNull(status.getMobData());


### PR DESCRIPTION
MobData no longer extends AliasedData. This allows us to create MobData that is unnamed. CommandData has been updated to no longer require a name.

This change also affects permissions related to CommandData. The command permission nodes have been reduced to a single `mobactions.command` node. This is because command permissions should be handled separately of our plugin, making the ability to allow/deny specific command mobs pointless.

This PR also includes a small fix to the CommandListener#onCommand() logic which might improve runtime and prevent future weird behavior, but should be largely unnoticeable to end-users.